### PR TITLE
Reduce the amount of logging from Mos gateway

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "production"
   ],
   "dependencies": {
-    "mos-connection": "^0.8.10",
+    "mos-connection": "0.0.1-nightly-feat-lessLogging-20200911-142900-7fcc351.0",
     "tslib": "^1.10.0",
     "tv-automation-server-core-integration": "1.5.1",
     "underscore": "^1.9.1",

--- a/src/mosHandler.ts
+++ b/src/mosHandler.ts
@@ -222,7 +222,7 @@ export class MosHandler {
 				this._heartbeatsAccumulated++
 				this._timeOfLastHeartbeat = Date.now()
 				if (this._timeOfLastHeartbeat > this._timeOfNextHeartReport) {
-					this._logger.info(`Received ${this._heartbeatsAccumulated} in the last minute or so.`)
+					this._logger.info(`Received ${this._heartbeatsAccumulated} heartbeats in the last minute or so.`)
 					this._heartbeatsAccumulated = 0
 					this._timeOfNextHeartReport = this._timeOfNextHeartReport + 60000
 				}

--- a/src/mosHandler.ts
+++ b/src/mosHandler.ts
@@ -211,6 +211,7 @@ export class MosHandler {
 		if (!this._settings.mosId) throw Error('mosId missing in settings!')
 		connectionConfig.mosID = this._settings.mosId
 
+		connectionConfig.debug = false
 		this.mos = new MosConnection(connectionConfig)
 		this.mos.on('rawMessage', (source, type, message) => {
 			this.debugLog('rawMessage', source, type, message)

--- a/src/mosHandler.ts
+++ b/src/mosHandler.ts
@@ -126,7 +126,7 @@ export class MosHandler {
 			// )
 		// })
 		.then(() => {
-
+			// All initialised and ready to go
 		})
 	}
 	dispose (): Promise<void> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3531,10 +3531,10 @@ moment@^2.24.0:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
-mos-connection@^0.8.10:
-  version "0.8.10"
-  resolved "https://registry.yarnpkg.com/mos-connection/-/mos-connection-0.8.10.tgz#370808bc8d17a1f3396875b3dba851ed272775a3"
-  integrity sha512-K8LoxYiHifhEJVyQHgjfRsDKFsI1LR1gt+NrP8DeafVUOl5i+vEcj+1wgDZxSaJ/pHuiPdh9l9R1nd2cX0gr5A==
+mos-connection@0.0.1-nightly-feat-lessLogging-20200911-142900-7fcc351.0:
+  version "0.0.1-nightly-feat-lessLogging-20200911-142900-7fcc351.0"
+  resolved "https://registry.yarnpkg.com/mos-connection/-/mos-connection-0.0.1-nightly-feat-lessLogging-20200911-142900-7fcc351.0.tgz#1956d0d549d9f869eb5140400471f6e5243582e9"
+  integrity sha512-HySx4Atce+hTKqQPOrLB0yYl5rt0l5jLibQtnjbVpDnUJnLPGecYyB7RSpoKp2QkH/1o0sNXi2tr09J3XmGG1g==
   dependencies:
     iconv-lite "^0.5.0"
     moment "^2.24.0"


### PR DESCRIPTION
MOS gateway logging was designed to be deliberately verbose as the development team learned the protocol. 

This PR reduces the amount of unnecessary, repetitive logging, especially for heartbeats.